### PR TITLE
Taskable jobs

### DIFF
--- a/src/SlmQueue/Job/TaskableJob.php
+++ b/src/SlmQueue/Job/TaskableJob.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace SlmQueue\Job;
+
+use Zend\Stdlib\SplPriorityQueue;
+use SlmQueue\Task\TaskInterface;
+
+/**
+ * A taskable job is a job that execute a specific set of tasks. The tasks are stored using a priority queue,
+ * so that the user can specified in which order the tasks need to be executed
+ */
+class TaskableJob extends AbstractJob
+{
+    /**
+     * @var SplPriorityQueue
+     */
+    protected $tasks;
+
+
+    /**
+     * {@inheritDoc}
+     */
+    public function __construct($content = null, array $metadata = array())
+    {
+        $this->tasks = new SplPriorityQueue();
+        parent::__construct($content, $metadata);
+    }
+
+    /**
+     * Insert a new task into the job
+     *
+     * @param TaskInterface $task
+     * @param mixed         $priority
+     */
+    public function addTask(TaskInterface $task, $priority)
+    {
+        $this->tasks->insert($task, $priority);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function execute()
+    {
+        /** @var $task TaskInterface */
+        foreach ($this->tasks as $task) {
+            $task->execute($this);
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function jsonSerialize()
+    {
+        $this->tasks->setExtractFlags(\SplPriorityQueue::EXTR_BOTH);
+
+        $data = array(
+            'class'   => get_called_class(),
+            'content' => $this->getContent(),
+            'tasks'   => array_map(function($task) {
+                return array(
+                    'priority' => $task['priority'],
+                    'class'    => get_class($task['priority'])
+                );
+            }, iterator_to_array($this->tasks))
+        );
+
+        return json_encode($data);
+    }
+}

--- a/src/SlmQueue/Task/TaskInterface.php
+++ b/src/SlmQueue/Task/TaskInterface.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace SlmQueue\Task;
+
+use SlmQueue\Job\JobInterface;
+
+/**
+ * TaskInterface
+ */
+interface TaskInterface
+{
+    /**
+     * Execute a single task of the job
+     *
+     * @param  JobInterface $job
+     * @return void
+     */
+    public function execute(JobInterface $job);
+}


### PR DESCRIPTION
ping @juriansluiman @Fraak

Not sure if this is a good idea or not but I found that in my future application, it would be much easier to decompose a job into multiple task (for instance for image processing where you would like to do resize, then do some operations... and those tasks could change).

So I created a new Task interface, and a TaskableJob that simply extends AbstractJob, and delegate the job to all the tasks that are inserted into a priority queue. It would work like that:

``` php
$job = new TaskableJob(array('name' => 'image1.jpg'));
$job->addTask(new ResizeTask(), 10);
$job->addTask(new IncreaseContrastTask(), 4);

if ($this->params('blackAndWhite')) {
    $job->addTask(new ConvertToBlackAndWhite(), 2);
}

$job->execute();
```

Of course if you like the idea, I'll add a TaskPluginManager so that task are pulled from the service locator too.
