### PR TITLE
Continue loop in worker when no job is returned

### DIFF
--- a/src/SlmQueue/Worker/AbstractWorker.php
+++ b/src/SlmQueue/Worker/AbstractWorker.php
@@ -68,7 +68,7 @@ abstract class AbstractWorker implements WorkerInterface
             foreach ($jobs as $job) {
                 // The queue may return null, for instance if a timeout was set
                 if (!$job instanceof JobInterface) {
-                    return $count;
+                    continue;
                 }
 
                 $this->processJob($job, $queue);


### PR DESCRIPTION
After a timeout, a queue can return nothing if no job is present. At this moment, the [worker quits](https://github.com/juriansluiman/SlmQueue/blob/master/src/SlmQueue/Worker/AbstractWorker.php#L71) which should not be the case. It should just do a `continue;` to get again in a new iteration of the loop.
