### PR TITLE
Make createJob a public method

### DIFF
--- a/src/SlmQueue/Queue/AbstractQueue.php
+++ b/src/SlmQueue/Queue/AbstractQueue.php
@@ -54,7 +54,7 @@ abstract class AbstractQueue implements QueueInterface
      * @param  array  $metadata
      * @return \SlmQueue\Job\JobInterface
      */
-    protected function createJob($className, $content = null, array $metadata = array())
+    public function createJob($className, $content = null, array $metadata = array())
     {
         /** @var $job \SlmQueue\Job\JobInterface */
         $job = $this->jobPluginManager->get($className);

--- a/tests/SlmQueueTest/Queue/QueueTest.php
+++ b/tests/SlmQueueTest/Queue/QueueTest.php
@@ -28,4 +28,61 @@ class QueueTest extends TestCase
         $this->assertInstanceOf('SlmQueueTest\Asset\SimpleJob', $job);
         $this->assertEquals('Foo', $job->getContent());
     }
+
+    public function testCanCreateJobWithStringName()
+    {
+        $job = new SimpleJob();
+        $jobPluginManager = $this->getMock('SlmQueue\Job\JobPluginManager');
+        $jobPluginManager->expects($this->once())
+                         ->method('get')
+                         ->with('SimpleJob')
+                         ->will($this->returnValue($job));
+
+        $queue  = new SimpleQueue('queue', $jobPluginManager);
+        $result = $queue->createJob('SimpleJob');
+
+        $expected = spl_object_hash($job);
+        $actual   = spl_object_hash($result);
+        $this->assertEquals($expected, $actual);
+    }
+
+    public function testCanCreateJobWithContent()
+    {
+        $job = $this->getMock('SlmQueue\Job\JobInterface');
+        $job->expects($this->once())
+            ->method('setContent')
+            ->with('Foo')
+            ->will($this->returnValue($job));
+
+        $jobPluginManager = $this->getMock('SlmQueue\Job\JobPluginManager');
+        $jobPluginManager->expects($this->once())
+                         ->method('get')
+                         ->with('SimpleJob')
+                         ->will($this->returnValue($job));
+
+        $queue  = new SimpleQueue('queue', $jobPluginManager);
+        $result = $queue->createJob('SimpleJob', 'Foo');
+    }
+
+    public function testCanCreateJobWithMetadata()
+    {
+        $job = $this->getMock('SlmQueue\Job\JobInterface');
+        $job->expects($this->once())
+            ->method('setContent')
+            ->will($this->returnValue($job));
+
+        $job->expects($this->once())
+            ->method('setMetadata')
+            ->with(array('foo' => 'Bar'))
+            ->will($this->returnValue($job));
+
+        $jobPluginManager = $this->getMock('SlmQueue\Job\JobPluginManager');
+        $jobPluginManager->expects($this->once())
+                         ->method('get')
+                         ->with('SimpleJob')
+                         ->will($this->returnValue($job));
+
+        $queue  = new SimpleQueue('queue', $jobPluginManager);
+        $result = $queue->createJob('SimpleJob', null, array('foo' => 'Bar'));
+    }
 }


### PR DESCRIPTION
This function is beneficial if you want to instantiate a job with
the job plugin manager and you have the queue instance present. The
other method is to pull the job plugin manager manually and set the
content and metadata yourself. This can be repeated for every job
you need to instantiate. So it's better to get this feature public.

The job instances must be created because only the instance (and no
string name) can be pushed into the queue. A second option could be
to allow jobs to be pushed with only string names:

`public function pushByName($name, $content, $metadata, $options)`

You can check existence of the job name within the job plugin manager:

`$this->jobPluginManager->has($name)`
