### PR TITLE
Add support for events

### DIFF
--- a/src/SlmQueue/Worker/WorkerEvent.php
+++ b/src/SlmQueue/Worker/WorkerEvent.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace SlmQueue\Worker;
+
+use SlmQueue\Job\JobInterface;
+use SlmQueue\Queue\QueueInterface;
+use Zend\EventManager\Event;
+
+/**
+ * WorkerEvent
+ */
+class WorkerEvent extends Event
+{
+    /**
+     * Various events you can listen to
+     */
+    const EVENT_PROCESS_QUEUE_PRE  = 'processQueue.pre';
+    const EVENT_PROCESS_QUEUE_POST = 'processQueue.post';
+    const EVENT_PROCESS_JOB_PRE    = 'processJob.pre';
+    const EVENT_PROCESS_JOB_POST   = 'processJob.post';
+
+    /**
+     * @var QueueInterface
+     */
+    protected $queue;
+
+    /**
+     * @var JobInterface|null
+     */
+    protected $job;
+
+    /**
+     * @param  JobInterface $job
+     * @return void
+     */
+    public function setJob(JobInterface $job)
+    {
+        $this->job = $job;
+    }
+
+    /**
+     * @return JobInterface|null
+     */
+    public function getJob()
+    {
+        return $this->job;
+    }
+
+    /**
+     * @param  QueueInterface $queue
+     * @return void
+     */
+    public function setQueue(QueueInterface $queue)
+    {
+        $this->queue = $queue;
+    }
+
+    /**
+     * @return QueueInterface
+     */
+    public function getQueue()
+    {
+        return $this->queue;
+    }
+}


### PR DESCRIPTION
@juriansluiman @basz

This PR adds support for events. As events add some overhead in ZF 2, I decided (according to our previous discussion), to keep it really simple. It triggers four events in the worker:
- EVENT_PROCESS_QUEUE_PRE : triggers after the queue is retrieved, but before any job to be processed.
- EVENT_PROCESS_JOB_PRE : triggers after one job is retrieved, but before it is executed.
- EVENT_PROCESS_JOB_POST : after the job is executed.
- EVENT_PROCESS_QUEUE_POST : after all the jobs are executed, or after a termination criteria is reached.

Queue events only have access to the queue, while job events have access to the queue and the job.

Listeners can be registered for all workers in a generic way (using the SlmQueue\Worker\WorkerInterface identifier) or using the concrete name of the worker instance.

If you like it, I'll add tests and write doc.

Question : should we make the interface EventManagerAwareInterface, and move the constnats to the worker interface instead of the abstract class?
