### PR TITLE
Allow to normalize options

### DIFF
--- a/src/SlmQueue/Controller/AbstractWorkerController.php
+++ b/src/SlmQueue/Controller/AbstractWorkerController.php
@@ -33,7 +33,7 @@ abstract class AbstractWorkerController extends AbstractActionController
      */
     public function processAction()
     {
-        $options = $this->params()->fromRoute();
+        $options = $this->normalizeOptions($this->params()->fromRoute());
         $queue   = $options['queue'];
 
         try {
@@ -50,5 +50,16 @@ abstract class AbstractWorkerController extends AbstractActionController
             $queue,
             $result
         );
+    }
+
+    /**
+     * This method is used to normalize options, if the name used in options is different
+     *
+     * @param  array $options
+     * @return array
+     */
+    protected function normalizeOptions(array $options = array())
+    {
+        return $options;
     }
 }


### PR DESCRIPTION
This PR allows to provide an easy way to normalize options in controller. This was needed because in SQS, for instance, the params in the console are shorter name using camelCase (example: maxJobs), while those needs to be converted to name that map the underlying queue system and using underscore_separated as this is ZF2 convention for options (this needs to be converted to max_number_of_messages).

Because of this, and to solve more elegantly my problem of SQS, I suggest:
- We add the BatchableQueue interface in SlmQueue with batchPop, batchPush and batchDelete. Most of those can be emulated in most queue systems.
- We standardize the name for the "maxJobs" options in controller. This way, we could modify the controller this way:

``` php
public function processAction()
    {
        $options = $this->params()->fromRoute();
        $queue   = $options['queue'];

        try {
             if ($options['maxJobs'] === 1) {
                  $options = $this->normalizeOptions($options);
                  $result = $this->worker->processQueue($queue, $options);
             } else {
                  $options = $this->normalizeOptions($options);
                  $result = $this->worker->processBatchQueue($queue, $options);
             }
        }

        return sprintf(
            "Finished worker for queue '%s' with %s jobs\n",
            $queue,
            $result
        );
    }
```

We introduce a new processBatchQueue in Worker.

Thoughts @juriansluiman @basz ?
