### PR TITLE
Inject queue into create job

### DIFF
--- a/src/SlmQueue/Queue/AbstractQueue.php
+++ b/src/SlmQueue/Queue/AbstractQueue.php
@@ -61,6 +61,10 @@ abstract class AbstractQueue implements QueueInterface
         $job->setContent(unserialize($content));
         $job->setMetadata($metadata);
 
+        if ($job instanceof QueueAwareInterface) {
+            $job->setQueue($this);
+        }
+
         return $job;
     }
 }

--- a/src/SlmQueue/Worker/AbstractWorker.php
+++ b/src/SlmQueue/Worker/AbstractWorker.php
@@ -82,11 +82,6 @@ abstract class AbstractWorker implements WorkerInterface, EventManagerAwareInter
                 continue;
             }
 
-            // The job might want to get the queue injected
-            if ($job instanceof QueueAwareInterface) {
-                $job->setQueue($queue);
-            }
-
             $workerEvent->setJob($job);
 
             $eventManager->trigger(WorkerEvent::EVENT_PROCESS_JOB_PRE, $workerEvent);

--- a/tests/SlmQueueTest/Queue/QueueTest.php
+++ b/tests/SlmQueueTest/Queue/QueueTest.php
@@ -4,6 +4,7 @@ namespace SlmQueueTest\Job;
 
 use DateTime;
 use PHPUnit_Framework_TestCase as TestCase;
+use SlmQueueTest\Asset\QueueAwareJob;
 use SlmQueueTest\Asset\SimpleQueue;
 use SlmQueueTest\Asset\SimpleJob;
 
@@ -85,5 +86,22 @@ class QueueTest extends TestCase
 
         $queue  = new SimpleQueue('queue', $jobPluginManager);
         $result = $queue->createJob('SimpleJob', null, array('foo' => 'Bar'));
+    }
+
+    public function testCreateQueueAwareJob()
+    {
+        $job = new QueueAwareJob();
+
+        $jobPluginManager = $this->getMock('SlmQueue\Job\JobPluginManager');
+        $jobPluginManager->expects($this->once())
+                         ->method('get')
+                         ->with('SlmQueueTest\Asset\QueueAwareJob')
+                         ->will($this->returnValue($job));
+
+        $queue = new SimpleQueue('queue', $jobPluginManager);
+
+        $result = $queue->createJob('SlmQueueTest\Asset\QueueAwareJob');
+
+        $this->assertSame($queue, $result->getQueue());
     }
 }

--- a/tests/SlmQueueTest/Worker/AbstractWorkerTest.php
+++ b/tests/SlmQueueTest/Worker/AbstractWorkerTest.php
@@ -67,20 +67,6 @@ class AbstractWorkerTest extends TestCase
         $this->worker->processQueue('foo');
     }
 
-    public function testWorkerInjectsQueueForAwareInterface()
-    {
-        $job = $this->getMock('SlmQueueTest\Asset\QueueAwareJob', array('setQueue'));
-        $job->expects($this->once())
-            ->method('setQueue')
-            ->with($this->queue);
-
-        $this->queue->expects($this->once())
-                    ->method('pop')
-                    ->will($this->returnValue($job));
-
-        $this->worker->processQueue('foo');
-    }
-
     public function testCorrectIdentifiersAreSetToEventManager()
     {
         $eventManager = $this->worker->getEventManager();


### PR DESCRIPTION
Hi,

Currently, if a job is a queue aware job, the queue is injected into the worker. The main issue is that sometimes, you cannot use the worker (for instance, I'm using a system that has a built-in worker that only submits me job, so it completely bypasses the worker). However, I'd like the queue to be injected if it is a QueueAware. Therefore, the best place for this should be in the "createJob" of the queue.

This should not be a BC.
