### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -367,7 +367,7 @@ class BootstrapTranslatorJobListener extends AbstractListenerAggregate {
         $this->handlers[] = $events->attach(WorkerEvent::EVENT_PROCESS_JOB_POST, array($this, 'onPostJobProcessing'));
     }
 
-    protected function onPreJobProcessing(WorkerEvent $e) {
+    public function onPreJobProcessing(WorkerEvent $e) {
         /** @var \SlmQueue\Job\JobInterface */
         $job = $e->getJob();
 
@@ -379,7 +379,7 @@ class BootstrapTranslatorJobListener extends AbstractListenerAggregate {
         $this->translator->setLocale($job->getLocale());
     }
 
-    protected function onPostJobProcessing(WorkerEvent $e) {
+    public function onPostJobProcessing(WorkerEvent $e) {
         $job = $e->getJob();
 
         if (!$job implements LocaleAwareJobInterface) {


### PR DESCRIPTION
Fixed bug: 

Zend\Stdlib\Exception\InvalidCallbackException: Invalid callback provided; not callable in /Users/andrew/Sites/hobart/website/vendor/zendframework/zendframework/library/Zend/Stdlib/CallbackHandler.php on line 63

Callbacks should be public!
