### PR TITLE
Always use default queue listener

### DIFF
--- a/src/SlmQueue/Strategy/AttachQueueListenersStrategy.php
+++ b/src/SlmQueue/Strategy/AttachQueueListenersStrategy.php
@@ -48,14 +48,14 @@ class AttachQueueListenersStrategy extends AbstractStrategy
     public function attachQueueListeners(WorkerEvent $e)
     {
         /** @var AbstractWorker $worker */
-        $worker = $e->getTarget();
-        $name = $e->getQueue()->getName();
+        $worker       = $e->getTarget();
+        $name         = $e->getQueue()->getName();
         $eventManager = $worker->getEventManager();
 
         $eventManager->detachAggregate($this);
 
         if (!isset($this->strategyConfig[$name])) {
-            return;
+            $name = 'default'; // We want to make sure the default process queue is always attached
         }
 
         $strategies = $this->strategyConfig[$name];

--- a/tests/SlmQueueTest/Strategy/AttachQueueListenersStrategyTest.php
+++ b/tests/SlmQueueTest/Strategy/AttachQueueListenersStrategyTest.php
@@ -63,29 +63,38 @@ class AttachQueueListenersStrategyTest extends PHPUnit_Framework_TestCase
         $this->listener->attach($evm);
     }
 
-    public function testAttachQueueListenersDetachedSelfFromEventManager() {
-
+    public function testAttachQueueListenersDetachedSelfFromEventManager()
+    {
         $workerMock       = $this->event->getTarget();
         $eventManagerMock = $workerMock->getEventManager();
         $eventManagerMock->expects($this->once())->method('detachAggregate')->with($this->listener);
         $eventManagerMock->expects($this->any())->method('getEvents')->will($this->returnValue(array(WorkerEvent::EVENT_PROCESS)));
+        $eventManagerMock->expects($this->once())->method('trigger');
 
         $this->listener->attachQueueListeners($this->event);
     }
 
-    public function testAttachQueueListenersHaltsQueueNameIsNotInStrategyConfig() {
+    public function testAttachQueueListenerFallbackToDefaultIfQueueNameIsNotMatched()
+    {
+        $workerMock       = $this->event->getTarget();
+        $eventManagerMock = $workerMock->getEventManager();
+        $eventManagerMock->expects($this->any())->method('getEvents')->will($this->returnValue(array(WorkerEvent::EVENT_PROCESS)));
+
         $class = new \ReflectionClass('SlmQueue\Strategy\AttachQueueListenersStrategy');
         $property = $class->getProperty('strategyConfig');
         $property->setAccessible(true);
 
-        $property->setValue($this->listener, array('unknownQueueName' => array(
+        $property->setValue($this->listener, array(
+            'default' => array(
                 'SlmQueue\Strategy\SomeStrategy',
-            )));
+            )
+        ));
 
-        $this->isNull($this->listener->attachQueueListeners($this->event));
+        $this->listener->attachQueueListeners($this->event);
     }
 
-    public function testAttachQueueListenersStrategyConfig() {
+    public function testAttachQueueListenersStrategyConfig()
+    {
         $workerMock       = $this->event->getTarget();
         $eventManagerMock = $workerMock->getEventManager();
         $eventManagerMock->expects($this->any())->method('getEvents')->will($this->returnValue(array(WorkerEvent::EVENT_PROCESS)));


### PR DESCRIPTION
ping @basz 

We definitely don't want to force people to define the ProcessQueue for ech of their queue, so we use the default one if none is defined.
