### PR TITLE
 Deprecate Interop\Container\ContainerInterface

### DIFF
--- a/src/Factory/JobPluginManagerFactory.php
+++ b/src/Factory/JobPluginManagerFactory.php
@@ -2,9 +2,9 @@
 
 namespace SlmQueue\Factory;
 
-use Interop\Container\ContainerInterface;
 use Laminas\ServiceManager\FactoryInterface;
 use Laminas\ServiceManager\ServiceLocatorInterface;
+use Psr\Container\ContainerInterface;
 use SlmQueue\Job\JobPluginManager;
 
 class JobPluginManagerFactory implements FactoryInterface

--- a/src/Factory/QueueControllerPluginFactory.php
+++ b/src/Factory/QueueControllerPluginFactory.php
@@ -2,8 +2,8 @@
 
 namespace SlmQueue\Factory;
 
-use Interop\Container\ContainerInterface;
 use Laminas\ServiceManager\Factory\FactoryInterface;
+use Psr\Container\ContainerInterface;
 use SlmQueue\Controller\Plugin\QueuePlugin;
 use SlmQueue\Job\JobPluginManager;
 use SlmQueue\Queue\QueuePluginManager;

--- a/src/Factory/QueuePluginManagerFactory.php
+++ b/src/Factory/QueuePluginManagerFactory.php
@@ -2,8 +2,8 @@
 
 namespace SlmQueue\Factory;
 
-use Interop\Container\ContainerInterface;
 use Laminas\ServiceManager\Factory\FactoryInterface;
+use Psr\Container\ContainerInterface;
 use SlmQueue\Queue\QueuePluginManager;
 
 class QueuePluginManagerFactory implements FactoryInterface

--- a/src/Factory/StrategyPluginManagerFactory.php
+++ b/src/Factory/StrategyPluginManagerFactory.php
@@ -2,8 +2,8 @@
 
 namespace SlmQueue\Factory;
 
-use Interop\Container\ContainerInterface;
 use Laminas\ServiceManager\Factory\FactoryInterface;
+use Psr\Container\ContainerInterface;
 use SlmQueue\Strategy\StrategyPluginManager;
 
 class StrategyPluginManagerFactory implements FactoryInterface

--- a/src/Factory/WorkerAbstractFactory.php
+++ b/src/Factory/WorkerAbstractFactory.php
@@ -2,10 +2,10 @@
 
 namespace SlmQueue\Factory;
 
-use Interop\Container\ContainerInterface;
 use Laminas\EventManager\EventManager;
 use Laminas\EventManager\EventManagerInterface;
 use Laminas\ServiceManager\Factory\AbstractFactoryInterface;
+use Psr\Container\ContainerInterface;
 use SlmQueue\Strategy\StrategyPluginManager;
 use SlmQueue\Worker\WorkerInterface;
 

--- a/src/Factory/WorkerPluginManagerFactory.php
+++ b/src/Factory/WorkerPluginManagerFactory.php
@@ -2,8 +2,8 @@
 
 namespace SlmQueue\Factory;
 
-use Interop\Container\ContainerInterface;
 use Laminas\ServiceManager\Factory\FactoryInterface;
+use Psr\Container\ContainerInterface;
 use SlmQueue\Worker\WorkerPluginManager;
 
 class WorkerPluginManagerFactory implements FactoryInterface

--- a/src/Strategy/Factory/AttachQueueListenersStrategyFactory.php
+++ b/src/Strategy/Factory/AttachQueueListenersStrategyFactory.php
@@ -2,9 +2,9 @@
 
 namespace SlmQueue\Strategy\Factory;
 
-use Interop\Container\ContainerInterface;
 use Laminas\ServiceManager\Factory\FactoryInterface;
 use Laminas\ServiceManager\ServiceLocatorInterface;
+use Psr\Container\ContainerInterface;
 use SlmQueue\Strategy\AttachQueueListenersStrategy;
 use SlmQueue\Strategy\StrategyPluginManager;
 

--- a/tests/src/Asset/FileQueueFactory.php
+++ b/tests/src/Asset/FileQueueFactory.php
@@ -2,8 +2,8 @@
 
 namespace SlmQueueTest\Asset;
 
-use Interop\Container\ContainerInterface;
 use Laminas\ServiceManager\Factory\FactoryInterface;
+use Psr\Container\ContainerInterface;
 use SlmQueue\Job\JobPluginManager;
 
 class FileQueueFactory implements FactoryInterface

--- a/tests/src/Asset/SimpleQueueFactory.php
+++ b/tests/src/Asset/SimpleQueueFactory.php
@@ -2,8 +2,8 @@
 
 namespace SlmQueueTest\Asset;
 
-use Interop\Container\ContainerInterface;
 use Laminas\ServiceManager\Factory\FactoryInterface;
+use Psr\Container\ContainerInterface;
 use SlmQueue\Job\JobPluginManager;
 
 class SimpleQueueFactory implements FactoryInterface


### PR DESCRIPTION
> Starting Feb. 13th 2017, container-interop is officially deprecated in favor of PSR-11.

Given that [ContainerInterop's README](https://github.com/container-interop/container-interop#readme) starts off with the statement above, then it makes sense to deprecate the package in favour of `Psr\Container\ContainerInterface`, which this change does.