### PR TITLE
Allow float values of maxFrequency

### DIFF
--- a/src/Strategy/MaxPollingFrequencyStrategy.php
+++ b/src/Strategy/MaxPollingFrequencyStrategy.php
@@ -9,7 +9,7 @@ use SlmQueue\Worker\Event\WorkerEventInterface;
 class MaxPollingFrequencyStrategy extends AbstractStrategy
 {
     /**
-     * @var int
+     * @var float
      */
     protected $maxFrequency;
 
@@ -45,12 +45,12 @@ class MaxPollingFrequencyStrategy extends AbstractStrategy
         $this->lastTime = microtime(true);
     }
 
-    public function setMaxFrequency(int $maxFrequency): void
+    public function setMaxFrequency(float $maxFrequency): void
     {
         $this->maxFrequency = $maxFrequency;
     }
 
-    public function getMaxFrequency(): int
+    public function getMaxFrequency(): float
     {
         return $this->maxFrequency;
     }

--- a/tests/src/Strategy/MaxPollingFrequencyStrategyTest.php
+++ b/tests/src/Strategy/MaxPollingFrequencyStrategyTest.php
@@ -37,6 +37,13 @@ class MaxPollingFrequencyStrategyTest extends TestCase
         static::assertEquals(100, $this->listener->getMaxFrequency());
     }
 
+    public function testMaxPollingFrequencySetterFractional(): void
+    {
+        $this->listener->setMaxFrequency(0.1);
+
+        static::assertEquals(0.1, $this->listener->getMaxFrequency());
+    }
+
     public function testListensToCorrectEventAtCorrectPriority(): void
     {
         $evm = $this->createMock(EventManagerInterface::class);


### PR DESCRIPTION
Allowing maxFrequency to be a float ensures that frequencies of less than 1 can be used, which allows delays of more than 1 second.

Fixes #248