### PR TITLE
Update minimum laminas-servicemanager version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,7 @@
     "require": {
         "php": "^7.4 || ~8.0",
         "laminas/laminas-eventmanager": "^3.3",
-        "laminas/laminas-servicemanager": "^3.6",
+        "laminas/laminas-servicemanager": "^3.11",
         "laminas/laminas-stdlib": "^3.3",
         "laminas/laminas-cli": "^1.1.1"
     },


### PR DESCRIPTION
As part of deprecating `Interop\Container\ContainerInterface`, this change bumps the minimum version of laminas-servicemanager that the package relies upon, to 3.11, so that it starts off with the release that also deprecated `Interop\Container\ContainerInterface`.