### PR TITLE
Throw exception on invalid job content

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,6 +33,7 @@
     ],
     "require": {
         "php": "~7.4.0 || ~8.0.0 || ~8.1.0",
+        "ext-json": "*",
         "laminas/laminas-eventmanager": "^3.4",
         "laminas/laminas-servicemanager": "^3.11",
         "laminas/laminas-stdlib": "^3.7.1",

--- a/src/Queue/AbstractQueue.php
+++ b/src/Queue/AbstractQueue.php
@@ -90,6 +90,6 @@ abstract class AbstractQueue implements QueueInterface
             $data['content'] = base64_encode($data['content']);
         }
 
-        return json_encode($data);
+        return json_encode($data, JSON_THROW_ON_ERROR);
     }
 }

--- a/tests/src/Queue/QueueTest.php
+++ b/tests/src/Queue/QueueTest.php
@@ -2,6 +2,7 @@
 
 namespace SlmQueueTest\Queue;
 
+use JsonException;
 use Laminas\ServiceManager\ServiceManager;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
@@ -131,6 +132,17 @@ class QueueTest extends TestCase
         $actual = $this->queue->serializeJob($job);
 
         static::assertEquals($expected, $actual);
+    }
+
+    public function testInvalidSerializeJobContent(): void
+    {
+        $job = new SimpleJob();
+        $job->setMetadata('__name__', 'SimpleJob');
+        $job->setContent(chr(128));
+
+        $this->expectException(JsonException::class);
+
+        $this->queue->serializeJob($job);
     }
 
     public function testCanCreateJobWithFQCN(): void


### PR DESCRIPTION
While encoding job data  `json_encode` might return `false` and that value would be returned as an empty string by `serializeJob` method.
This is because `AbstractQueue` is not using script types.

To prevent it `JSON_THROW_ON_ERROR` flag could be used instead of adding strict type declaration.