### PR TITLE
Support PHP 8.2

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,6 +18,7 @@ jobs:
                     - "7.4"
                     - "8.0"
                     - "8.1"
+                    - "8.2"
                 dependencies:
                     - "highest"
                     - "lowest"

--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
         }
     ],
     "require": {
-        "php": "~7.4.0 || ~8.0.0 || ~8.1.0",
+        "php": "~7.4.0 || ~8.0.0 || ~8.1.0 || ~8.2.0",
         "ext-json": "*",
         "laminas/laminas-eventmanager": "^3.4",
         "laminas/laminas-servicemanager": "^3.11",
@@ -40,7 +40,7 @@
         "laminas/laminas-cli": "^1.2"
     },
     "require-dev": {
-        "laminas/laminas-mvc": "^3.3",
+        "laminas/laminas-mvc": "^3.3 || ^3.4",
         "laminas/laminas-modulemanager": "^2.11",
         "laminas/laminas-view": "^2.13",
         "laminas/laminas-serializer": "^2.11",

--- a/tests/integration/laminas/composer.json
+++ b/tests/integration/laminas/composer.json
@@ -1,7 +1,7 @@
 {
     "require": {
         "slm/queue": "*",
-        "laminas/laminas-mvc": "3.3"
+        "laminas/laminas-mvc": "3.3 || 3.4"
     },
     "repositories": [
         {


### PR DESCRIPTION
We're hoping to upgrade our application to 8.2 but are currently blocked by SlmQueue (and SlmQueueDoctrine) only supporting ≤8.1.

I don't know enough about how your tests work to understand if what I've done is sufficient evidence that 8.2 is supported, happy to try adding things to this PR if I've missed something.

I've updated the `composer.json` file and testing matrix, and allowed supporting both laminas-mvc 3.3 (for PHP7.4) and 3.4 (for PHP8.x).